### PR TITLE
Eventモデルの作成とバリデーションの追加

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ApplicationRecord
-  validates :title, presence: true, length: { maximum: 100 }, uniqueness: { scope: [:user_id, :title]  }
+  validates :title, presence: true, length: { maximum: 100 }, uniqueness: { scope: [:user_id, :title] }
+  validates :url_path, presence: true, uniqueness: true
   belongs_to :user
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,3 @@
+class Event < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 100 }, uniqueness: { scope: [:user_id, :title]  }
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,3 +1,4 @@
 class Event < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }, uniqueness: { scope: [:user_id, :title]  }
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,5 @@ class User < ApplicationRecord
   validates :name, presence: true
   VALID_DOMAIN_REGEX = /@mwed.co.jp\z/
   validates :email, presence: true, uniqueness: true, format: { with: VALID_DOMAIN_REGEX }
+  has_many :events
 end

--- a/db/migrate/20180613072512_create_events.rb
+++ b/db/migrate/20180613072512_create_events.rb
@@ -1,0 +1,12 @@
+class CreateEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :events do |t|
+      t.references :user
+      t.string :title
+
+      t.timestamps
+    end
+    
+    add_index :events, [:user_id, :title], unique: true
+  end
+end

--- a/db/migrate/20180614051014_add_column_events.rb
+++ b/db/migrate/20180614051014_add_column_events.rb
@@ -1,0 +1,5 @@
+class AddColumnEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events, :url_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_05_073529) do
+ActiveRecord::Schema.define(version: 2018_06_13_072512) do
+
+  create_table "events", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "title"], name: "index_events_on_user_id_and_title", unique: true
+    t.index ["user_id"], name: "index_events_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_13_072512) do
+ActiveRecord::Schema.define(version: 2018_06_14_051014) do
 
   create_table "events", force: :cascade do |t|
     t.integer "user_id"
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "url_path"
     t.index ["user_id", "title"], name: "index_events_on_user_id_and_title", unique: true
     t.index ["user_id"], name: "index_events_on_user_id"
   end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :event do
     title '第一回飲み会'
+    url_path 'this.is.20characters'
     association :user, factory: :user
   end
 end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :event do
-    title 'Example title'
-
-    user
+    title '第一回飲み会'
+    association :user, factory: :user
   end
 end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :event do
+    title 'Example title'
+
+    user
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -14,14 +14,26 @@ RSpec.describe Event, type: :model do
       end
 
       context "タイトルが100文字以上の時" do
-        let(:empty_name_event) { build(:event, title: 'これは１５文字のタイトルです。' * 7) }
-        it { expect(empty_name_event).to be_invalid }
+        let(:long_title_event) { build(:event, title: 'これは１５文字のタイトルです。' * 7) }
+        it { expect(long_title_event).to be_invalid }
       end
 
       context "同じユーザーが同じタイトルのイベントを作った時" do
         let(:event) { create(:event) }
         let(:dup_event) { event.dup }
         it { expect(dup_event).to be_invalid }
+      end
+
+      context "イベント用のURLが無い時" do
+        let(:empty_url_event) { build(:event, url_path: '') }
+        it { expect(empty_url_event).to be_invalid }
+      end
+
+      context "イベントURLが重複した時" do
+        before { create(:event) }
+        other_user = User.create(name: 'Mr.other_example', email: 'other_example@mwed.co.jp')
+        let(:same_url_event) { build(:event, user_id: other_user.id, title: '第1回飲み会（仮）') }
+        it { expect(same_url_event).to be_invalid }
       end
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Event, type: :model do
       end
 
       context "タイトルが100文字以上の時" do
-        let(:empty_name_event) { build(:event, title: 'Example title' * 8) }
+        let(:empty_name_event) { build(:event, title: 'これは１５文字のタイトルです。' * 7) }
         it { expect(empty_name_event).to be_invalid }
       end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  describe "バリデーション" do
+    context "正しい値の時" do
+      let(:event) { build(:event) }
+      it { expect(event).to be_valid }
+    end
+
+    context "不正な値の時" do
+      context "タイトルが空の時" do
+        let(:empty_name_event) { build(:event, title: '') }
+        it { expect(empty_name_event).to be_invalid }
+      end
+
+      context "タイトルが100文字以上の時" do
+        let(:empty_name_event) { build(:event, title: 'Example title' * 8) }
+        it { expect(empty_name_event).to be_invalid }
+      end
+
+      context "同じユーザーが同じタイトルのイベントを作った時" do
+        let(:event) { create(:event) }
+        let(:dup_event) { event.dup }
+        it { expect(dup_event).to be_invalid }
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 目的
Eventモデルの作成とバリデーションの追加

#内容
Eventモデルの作成、バリデーションの追加を行いました。Eventモデルはuser_idとtitleの組み合わせが一意でなければならないとしています。また、タイトル（イベント名）が最長100文字なのは本家である調整さんがそうだからです。

よろしくお願いします。
