### PR TITLE
Eventリソースへのアクセス方法の変更

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,7 +22,7 @@ class EventsController < ApplicationController
     @event_form = EventForm.new(event_params.merge({ user: current_user }))
 
     if @event_form.event = @event_form.create
-      redirect_to @event_form.event.url_path, notice: 'Event was successfully created.'
+      redirect_to event_path(@event_form.event.url_path), notice: 'Event was successfully created.'
     else
       render :new
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,7 +21,7 @@ class EventsController < ApplicationController
     @event_form = EventForm.new(event_params.merge({ user: current_user }))
 
     if @event_form.event = @event_form.create
-      redirect_to @event_form.event, notice: 'Event was successfully created.'
+      redirect_to @event_form.event.url_path, notice: 'Event was successfully created.'
     else
       render :new
     end
@@ -45,7 +45,7 @@ class EventsController < ApplicationController
 
   private
     def set_event
-      @event = Event.find_by(id: params[:id])
+      @event = Event.find_by(url_path: params[:url_path])
     end
 
     def event_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,5 @@
 class EventsController < ApplicationController
+  before_action :logged_in?, except: [:index]
   before_action :set_event, except: [:index, :new, :create]
 
   def index

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -2,4 +2,10 @@ module SessionsHelper
   def current_user
     @current_user ||= User.find_by(id: session[:user_id])
   end
+
+  def logged_in?
+    unless current_user.present?
+      redirect_to root_path, notice: 'ログインしてください。'
+    end
+  end
 end

--- a/app/models/event_form.rb
+++ b/app/models/event_form.rb
@@ -21,6 +21,6 @@ class EventForm
     end
 
     def event_dates
-      event_dates_text.split("\r\n").inject(Array.new) {|array, value| array.push({ event_date: value })}
+      event_dates_text.split(/[\r\n]+|\r+|\n+/).inject(Array.new) {|array, value| array.push({ event_date: value })}
     end
 end

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -6,12 +6,13 @@
       %th Title
       %th{:colspan => "3"}
   %tbody
-    - @events.each do |event|
-      %tr
-        %td= event.user_id
-        %td= event.title
-        %td= link_to 'Show', event
-        %td= link_to 'Edit', edit_event_path(event)
-        %td= link_to 'Destroy', event, method: :delete, data: { confirm: 'Are you sure?' }
+    - if @events
+      - @events.each do |event|
+        %tr
+          %td= event.user_id
+          %td= event.title
+          %td= link_to 'Show', event_path(event.url_path)
+          %td= link_to 'Edit', edit_event_path(event.url_path)
+          %td= link_to 'Destroy', event_path(event.url_path), method: :delete, data: { confirm: 'Are you sure?' }
 %br/
 = link_to 'New Event', new_event_path

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -6,7 +6,8 @@
   = @event.title
 %ul
   - @event.event_dates.each do |event_date|
-    %li= event_date.event_date  
+    %li= event_date.event_date
+%input{ type: 'text', size: 25, onfocus: 'this.select();', value: @event.url_path }
 = link_to 'Edit', edit_event_path(@event.url_path)
 |
 = link_to 'Back', events_path

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -7,6 +7,6 @@
 %ul
   - @event.event_dates.each do |event_date|
     %li= event_date.event_date  
-= link_to 'Edit', edit_event_path(@event)
+= link_to 'Edit', edit_event_path(@event.url_path)
 |
 = link_to 'Back', events_path

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -7,7 +7,7 @@
 %ul
   - @event.event_dates.each do |event_date|
     %li= event_date.event_date
-%input{ type: 'text', size: 25, onfocus: 'this.select();', value: @event.url_path }
+%input{ type: 'text', size: 25, onfocus: 'this.select();', value: event_url(@event.url_path) }
 = link_to 'Edit', edit_event_path(@event.url_path)
 |
 = link_to 'Back', events_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: 'sessions#new'
   resources :users, only: [:index, :show, :destroy]
-  resources :events
+  resources :events, param: 'url_path'
   get "/auth/google_oauth2", as: "google_auth"
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/login', to: 'sessions#new'

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe EventsController, type: :controller do
         it "イベントの詳細ページへリダイレクトする" do
           subject.call
           event = Event.find_by(title: valid_attributes[:title])
-          expect(response).to redirect_to event.url_path
+          expect(response).to redirect_to event_path(event.url_path)
         end
       end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -15,110 +15,161 @@ RSpec.describe EventsController, type: :controller do
   describe "GET #show" do
     subject { get :show, params: params }
 
-    context "イベントが存在する場合" do
-      let(:params) { { id: event.id } }
+    context "ログイン済みの場合" do
+      before do
+        event
+        log_in(event.user)
+      end
 
-      it { is_expected.to be_successful }
+      context "イベントが存在する場合" do
+        let(:params) { { url_path: event.url_path } }
+
+        it { is_expected.to be_successful }
+      end
+
+      context "イベントが存在しない場合" do
+        let(:params) { { url_path: event.url_path.split('').shuffle.join } }
+
+        it { is_expected.to redirect_to events_url }
+      end
     end
 
-    context "イベントが存在しない場合" do
-      let(:params) { { id: event.id + 1 } }
+    context "ログインしていない場合" do
+      let(:params) { { url_path: event.url_path } }
 
-      it { is_expected.to redirect_to events_url }
+      it { is_expected.to redirect_to root_url }
     end
   end
 
   describe "GET #new" do
     subject { get :new }
 
-    it { is_expected.to be_successful }
+    context "ログイン済みの場合" do
+      before do
+        event
+        log_in(event.user)
+      end
+
+      it { is_expected.to be_successful }
+    end
+
+    context "ログインしていない場合" do
+      it { is_expected.to redirect_to root_url }
+    end
   end
 
   describe "GET #edit" do
     subject { get :edit, params: params }
 
-    context "イベントが存在する場合" do
-      let(:params) { { id: event.id } }
+    context "ログイン済みの場合" do
+      before do
+        event
+        log_in(event.user)
+      end
 
-      it { is_expected.to be_successful }
+      context "イベントが存在する場合" do
+        let(:params) { { url_path: event.url_path } }
+
+        it { is_expected.to be_successful }
+      end
+
+      context "イベントが存在しない場合" do
+        let(:params) { { url_path: event.url_path.split('').shuffle.join } }
+
+        it { is_expected.to redirect_to events_url }
+      end
     end
 
-    context "イベントが存在しない場合" do
-      let(:params) { { id: event.id + 1 } }
+    context "ログインしていない場合" do
+      let(:params) { { url_path: event.url_path } }
 
-      it { is_expected.to redirect_to events_url }
+      it { is_expected.to redirect_to root_url }
     end
   end
 
   describe "POST #create" do
-    context "正しいパラメーターの場合" do
-      subject { proc { post :create, params: { event_form: valid_attributes } } }
-      before { log_in(user) }
+    context "ログイン済みの場合" do
+      before do
+        event
+        log_in(event.user)
+      end
 
-      it { is_expected.to change{ Event.count }.by(1) }
+      context "正しいパラメーターの場合" do
+        subject { proc { post :create, params: { event_form: valid_attributes } } }
 
-      it "イベントの詳細ページへリダイレクトする" do
-        subject.call
-        event = Event.find_by(title: valid_attributes[:title])
-        expect(response).to redirect_to event
+        it { is_expected.to change{ Event.count }.by(1) }
+
+        it "イベントの詳細ページへリダイレクトする" do
+          subject.call
+          event = Event.find_by(title: valid_attributes[:title])
+          expect(response).to redirect_to event.url_path
+        end
+      end
+
+      context "不正なパラメーターの場合" do
+        subject { post :create, params: { event_form: attributes } }
+
+        context "タイトルが空の場合" do
+          let(:attributes) { { title: '', event_dates_text: "2018/06/18\r\n2018/06/19\r\n2018/06/20" } }
+
+          it { is_expected.to render_template(:new) }
+        end
       end
     end
 
-    context "不正なパラメーターの場合" do
-      subject { post :create, params: { event_form: attributes } }
+    context "ログインしていない場合" do
+      subject { post :create, params: { event_form: valid_attributes } }
 
-      context "作成者が不明な場合" do
-        let(:attributes) { { title: '飲み会テストタイトル', event_dates_text: "2018/06/18\r\n2018/06/19\r\n2018/06/20" } }
-
-        it { is_expected.to render_template(:new) }
-      end
-
-      context "タイトルが空の場合" do
-        before { log_in(user) }
-        let(:attributes) { { title: '', event_dates_text: "2018/06/18\r\n2018/06/19\r\n2018/06/20" } }
-
-        it { is_expected.to render_template(:new) }
-      end
+      it { is_expected.to redirect_to root_path }
     end
   end
 
   describe "PUT #update" do
-    context "正しいパラメーターの場合" do
+    context "ログイン済みの場合" do
       before do
-        old_title
-        put :update, params: { id: event.id, event_form: attributes }
+        event
+        log_in(event.user)
       end
 
-      let(:old_title) { event.title }
-      let(:attributes) { { title: '新飲み会テストタイトル' } }
-      let(:updated_event) { Event.find_by(title: attributes[:title]) }
-
-      it { expect(updated_event.title).not_to eq old_title }
-
-      it { is_expected.to redirect_to updated_event }
-    end
-
-    context "不正なパラメーターの場合" do
-      subject { put :update, params: { id: event_id, event_form: attributes } }
-
-      context "イベントが存在しない場合" do
+      context "正しいパラメーターの場合" do
         before do
-          event
-          log_in(event.user)
+          old_title
+          put :update, params: { url_path: event.url_path, event_form: attributes }
         end
 
-        let(:attributes) { { title: '飲み会テストタイトル' } }
-        let(:event_id) { event.id + 1 }
+        let(:old_title) { event.title }
+        let(:attributes) { { title: '新飲み会テストタイトル' } }
+        let(:updated_event) { Event.find_by(url_path: event.url_path) }
 
-        it { is_expected.to render_template(:edit) }
+        it { expect(updated_event.title).not_to eq old_title }
+
+        it { is_expected.to redirect_to updated_event }
       end
 
-      context "タイトルが空の場合" do
-        let(:attributes) { { title: '' } }
-        let(:event_id) { event.id }
+      context "不正なパラメーターの場合" do
+        subject { put :update, params: { url_path: event_url_path, event_form: attributes } }
 
-        it { is_expected.to render_template(:edit) }
+        context "イベントが存在しない場合" do
+          let(:attributes) { { title: '飲み会テストタイトル' } }
+          let(:event_url_path) { event.url_path.split('').to_a.shuffle.join }
+
+          it { is_expected.to render_template(:edit) }
+        end
+
+        context "タイトルが空の場合" do
+          let(:attributes) { { title: '' } }
+          let(:event_url_path) { event.url_path }
+
+          it { is_expected.to render_template(:edit) }
+        end
       end
+    end
+
+    context "ログインしていない場合" do
+      subject { put :update, params: { url_path: event.url_path, event_form: attributes } }
+      let(:attributes) { { title: '飲み会テストタイトル' } }
+
+      it { is_expected.to redirect_to root_path }
     end
   end
 
@@ -126,18 +177,31 @@ RSpec.describe EventsController, type: :controller do
     subject { delete :destroy, params: params }
     before{ event }
 
-    context "イベントが存在する場合" do
-      let(:params) { { id: event.id } }
+    context "ログイン済みの場合" do
+      before do
+        event
+        log_in(event.user)
+      end
 
-      it { expect{ subject }.to change{ Event.count }.by(-1) }
+      context "イベントが存在する場合" do
+        let(:params) { { url_path: event.url_path } }
 
-      it { is_expected.to redirect_to events_url }
+        it { expect{ subject }.to change{ Event.count }.by(-1) }
+
+        it { is_expected.to redirect_to events_url }
+      end
+
+      context "イベントが存在しない場合" do
+        let(:params) { { url_path: event.url_path.split('').to_a.shuffle.join } }
+
+        it { is_expected.to render_template(:index) }
+      end
     end
 
-    context "イベントが存在しない場合" do
-      let(:params) { { id: event.id + 1 } }
+    context "ログインしていない場合" do
+      let(:params) { { url_path: event.url_path } }
 
-      it { is_expected.to render_template(:index) }
+      it { is_expected.to redirect_to root_url }
     end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe EventsController, type: :controller do
     context "ログイン済みの場合" do
       before do
         event
-        log_in(event.user)
+        log_in(user)
       end
 
       context "イベントが存在する場合" do
@@ -31,7 +31,7 @@ RSpec.describe EventsController, type: :controller do
       end
 
       context "イベントが存在しない場合" do
-        let(:params) { { url_path: event.url_path.split('').shuffle.join } }
+        let(:params) { { url_path: 'abc' } }
 
         it { is_expected.to redirect_to events_url }
       end
@@ -50,7 +50,7 @@ RSpec.describe EventsController, type: :controller do
     context "ログイン済みの場合" do
       before do
         event
-        log_in(event.user)
+        log_in(user)
       end
 
       it { is_expected.to be_successful }
@@ -77,7 +77,7 @@ RSpec.describe EventsController, type: :controller do
       end
 
       context "イベントが存在しない場合" do
-        let(:params) { { url_path: event.url_path.split('').shuffle.join } }
+        let(:params) { { url_path: 'abc' } }
 
         it { is_expected.to redirect_to events_url }
       end
@@ -155,7 +155,7 @@ RSpec.describe EventsController, type: :controller do
 
         context "イベントが存在しない場合" do
           let(:attributes) { { title: '飲み会テストタイトル' } }
-          let(:event_url_path) { event.url_path.split('').to_a.shuffle.join }
+          let(:event_url_path) { 'abc' }
 
           it { is_expected.to render_template(:edit) }
         end
@@ -195,7 +195,7 @@ RSpec.describe EventsController, type: :controller do
       end
 
       context "イベントが存在しない場合" do
-        let(:params) { { url_path: event.url_path.split('').to_a.shuffle.join } }
+        let(:params) { { url_path: 'abc' } }
 
         it { is_expected.to render_template(:index) }
       end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe EventsController, type: :controller do
   let(:event) { create(:event) }
   let(:valid_attributes) {
     { title: '飲み会テストタイトル',
-    event_dates_text: "6/18\r06/19\n06/20\r\n6/21\r\n\r\n6/22\n\n\n6/23\r\r\r\r6/24" }
+      event_dates_text: "6/18\r06/19\n06/20\r\n6/21\r\n\r\n6/22\n\n\n6/23\r\r\r\r6/24" }
    }
 
   describe "GET #index" do
@@ -101,7 +101,6 @@ RSpec.describe EventsController, type: :controller do
         subject { proc { post :create, params: { event_form: valid_attributes } } }
 
         it { is_expected.to change{ Event.count }.by(1) }
-
         it { is_expected.to change{ EventDate.count }.by(7) }
 
         it "イベントの詳細ページへリダイレクトする" do
@@ -192,7 +191,6 @@ RSpec.describe EventsController, type: :controller do
         let(:params) { { url_path: event.url_path } }
 
         it { expect{ subject }.to change{ Event.count }.by(-1) }
-
         it { is_expected.to redirect_to events_url }
       end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -145,7 +145,10 @@ RSpec.describe EventsController, type: :controller do
         let(:attributes) { { title: '新飲み会テストタイトル' } }
         let(:updated_event) { Event.find_by(url_path: event.url_path) }
 
-        it { expect(updated_event.title).not_to eq old_title }
+        it :aggregate_failures do
+          expect(updated_event.title).not_to eq old_title
+          expect(updated_event.title).to eq attributes[:title]
+        end
 
         it { is_expected.to redirect_to updated_event }
       end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe EventsController, type: :controller do
   include SessionTestHelper
   let(:user) { create(:user) }
   let(:event) { create(:event) }
-  let(:valid_attributes) { { title: '飲み会テストタイトル', event_dates_text: "2018/06/18\r\n2018/06/19\r\n2018/06/20" } }
+  let(:valid_attributes) {
+    { title: '飲み会テストタイトル',
+    event_dates_text: "6/18\r06/19\n06/20\r\n6/21\r\n\r\n6/22\n\n\n6/23\r\r\r\r6/24" }
+   }
 
   describe "GET #index" do
     subject { get :index }
@@ -98,6 +101,8 @@ RSpec.describe EventsController, type: :controller do
         subject { proc { post :create, params: { event_form: valid_attributes } } }
 
         it { is_expected.to change{ Event.count }.by(1) }
+
+        it { is_expected.to change{ EventDate.count }.by(7) }
 
         it "イベントの詳細ページへリダイレクトする" do
           subject.call

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,6 +1,14 @@
 FactoryBot.define do
+  sequence :email do |n|
+    "example#{n}@mwed.co.jp"
+  end
+
+  sequence :name do |n|
+    "Mr.example#{n}"
+  end
+
   factory :user do
-    name "Mr.example"
-    email "example@mwed.co.jp"
+    name
+    email
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,14 +1,6 @@
 FactoryBot.define do
-  sequence :email do |n|
-    "example#{n}@mwed.co.jp"
-  end
-
-  sequence :name do |n|
-    "Mr.example#{n}"
-  end
-
   factory :user do
-    name
-    email
+    sequence(:email) { |n| "example#{n}@mwed.co.jp" }
+    sequence(:name) { |n| "Mr.example#{n}" }
   end
 end

--- a/spec/models/event_form_spec.rb
+++ b/spec/models/event_form_spec.rb
@@ -7,11 +7,14 @@ RSpec.describe EventForm, type: :model do
     let(:user) { create(:user) }
 
     context "正しい値の場合" do
-      let(:attributes) { { title: "第一回飲み会", event_dates_text: "2018/06/18\r\n2018/06/19\r\n2018/06/20" } }
+      let(:attributes) {
+          { title: "第一回飲み会",
+            event_dates_text: "6/18\r06/19\n06/20\r\n6/21\r\n\r\n6/22\n\n\n6/23\r\r\r\r6/24" }
+        }
 
       it { is_expected.to be_truthy }
       it { expect { subject }.to change { Event.count }.by(1) }
-      it { expect { subject }.to change { EventDate.count }.by(3) }
+      it { expect { subject }.to change { EventDate.count }.by(7) }
 
       context "タイトルの文字数が100文字の場合" do
         let(:attributes) { { title: "これは１０文字です。" * 10, event_dates_text: "2018/06/18\r\n2018/06/19\r\n2018/06/20" } }

--- a/spec/models/event_form_spec.rb
+++ b/spec/models/event_form_spec.rb
@@ -7,10 +7,7 @@ RSpec.describe EventForm, type: :model do
     let(:user) { create(:user) }
 
     context "正しい値の場合" do
-      let(:attributes) {
-          { title: "第一回飲み会",
-            event_dates_text: "6/18\r06/19\n06/20\r\n6/21\r\n\r\n6/22\n\n\n6/23\r\r\r\r6/24" }
-        }
+      let(:attributes) { { title: "第一回飲み会", event_dates_text: "6/18\r06/19\n06/20\r\n6/21\r\n\r\n6/22\n\n\n6/23\r\r\r\r6/24" } }
 
       it { is_expected.to be_truthy }
       it { expect { subject }.to change { Event.count }.by(1) }


### PR DESCRIPTION
# 目的
（indexアクション以外で）Eventリソースへアクセスする際にはDBに入っているurl_pathを使い、ログインを必須にする

# 内容
今までUserリソース、Eventリソース、EventDateリソースを作成してきましたが、それぞれに関する認可の仕組みを実装していませんでした。また、Eventを取得する際にはidを使ってfindしていました。そこでevents controllerのindex以外のアクションではユーザーのログインを必須にし、該当するeventを取得する際にはURLに含まれるurl_pathを使って検索するようにしました。

また、ユーザーがURLを簡単に取得しやすいようにコピー用のフォームを作りました。

なお、このPRには#9 の分も含まれています。[Use url_path as parameter](https://github.com/masayoshi-toku/nomikai_adjustment/pull/10/commits/1379bf2cfd02f3e00cc9a083928fb0012339174c)からがこので更新したところです。

確認の方、よろしくお願いします。
