### PR TITLE
Reactionモデルの追加

### DIFF
--- a/app/models/event_date.rb
+++ b/app/models/event_date.rb
@@ -1,4 +1,5 @@
 class EventDate < ApplicationRecord
   belongs_to :event
+  has_many :reactions
   validates :event_date, presence: true, uniqueness: { scope: :event_id }
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,0 +1,5 @@
+class Reaction < ApplicationRecord
+  belongs_to :user
+  belongs_to :event_date
+  validates :status, presence: true, inclusion: { in: 1..3 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   VALID_DOMAIN_REGEX = /@mwed.co.jp\z/
   validates :email, presence: true, uniqueness: true, format: { with: VALID_DOMAIN_REGEX }
   has_many :events
+  has_many :reactions
 end

--- a/db/migrate/20180613072512_create_events.rb
+++ b/db/migrate/20180613072512_create_events.rb
@@ -1,12 +1,12 @@
 class CreateEvents < ActiveRecord::Migration[5.2]
   def change
     create_table :events do |t|
-      t.references :user
+      t.references :user, foreign_key: true
       t.string :title
 
       t.timestamps
     end
-    
+
     add_index :events, [:user_id, :title], unique: true
   end
 end

--- a/db/migrate/20180615042525_create_event_dates.rb
+++ b/db/migrate/20180615042525_create_event_dates.rb
@@ -1,7 +1,7 @@
 class CreateEventDates < ActiveRecord::Migration[5.2]
   def change
     create_table :event_dates do |t|
-      t.references :event
+      t.references :event, foreign_key: true
       t.string :event_date
 
       t.timestamps

--- a/db/migrate/20180620044428_create_reactions.rb
+++ b/db/migrate/20180620044428_create_reactions.rb
@@ -1,0 +1,11 @@
+class CreateReactions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :reactions do |t|
+      t.references :user, foreign_key: true
+      t.references :event_date, foreign_key: true
+      t.integer :status, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180620044428_create_reactions.rb
+++ b/db/migrate/20180620044428_create_reactions.rb
@@ -1,8 +1,8 @@
 class CreateReactions < ActiveRecord::Migration[5.2]
   def change
     create_table :reactions do |t|
-      t.references :user, foreign_key: true
-      t.references :event_date, foreign_key: true
+      t.references :user, foreign_key: true, null: false
+      t.references :event_date, foreign_key: true, null:false
       t.integer :status, null: false
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_18_084043) do
+ActiveRecord::Schema.define(version: 2018_06_20_044428) do
 
   create_table "event_dates", force: :cascade do |t|
     t.integer "event_id", null: false
@@ -29,6 +29,16 @@ ActiveRecord::Schema.define(version: 2018_06_18_084043) do
     t.string "url_path", null: false
     t.index ["user_id", "title"], name: "index_events_on_user_id_and_title", unique: true
     t.index ["user_id"], name: "index_events_on_user_id"
+  end
+
+  create_table "reactions", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "event_date_id"
+    t.integer "status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_date_id"], name: "index_reactions_on_event_date_id"
+    t.index ["user_id"], name: "index_reactions_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,8 +32,8 @@ ActiveRecord::Schema.define(version: 2018_06_20_044428) do
   end
 
   create_table "reactions", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "event_date_id"
+    t.integer "user_id", null: false
+    t.integer "event_date_id", null: false
     t.integer "status", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
-  include SessionTestHelper
   let(:user) { create(:user) }
   let(:event) { create(:event) }
   let(:valid_attributes) {

--- a/spec/factories/reaction_factory.rb
+++ b/spec/factories/reaction_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :reaction do
+    status 1
+    association :user, factory: :user
+    association :event_date, factory: :event_date
+  end
+end

--- a/spec/factories/reaction_factory.rb
+++ b/spec/factories/reaction_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :reaction do
-    status 1
     association :user, factory: :user
     association :event_date, factory: :event_date
+    status 1
   end
 end

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -22,8 +22,13 @@ RSpec.describe Reaction, type: :model do
         end
 
         context "値が1~3以外である時" do
-          [4..10].each do |status|
-            let(:attribute) { status }
+          context "値が0の時" do
+            let(:attribute) { 0 }
+            it { is_expected.to be_invalid }
+          end
+
+          context "値が4の時" do
+            let(:attribute) { 4 }
             it { is_expected.to be_invalid }
           end
         end

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Reaction, type: :model do
+  describe "バリデーション" do
+    context "正しい値の時" do
+      subject { build(:reaction) }
+      it { is_expected.to be_valid }
+    end
+
+    context "不正な値の時" do
+      context "ステータスに不正な値がある時" do
+        subject { build(:reaction, status: attribute) }
+
+        context "存在しない時" do
+          let(:attribute) { nil }
+          it { is_expected.to be_invalid }
+        end
+
+        context "空である時" do
+          let(:attribute) { '' }
+          it { is_expected.to be_invalid }
+        end
+
+        context "値が1~3以外である時" do
+          [4..10].each do |status|
+            let(:attribute) { status }
+            it { is_expected.to be_invalid }
+          end
+        end
+      end
+
+      context "ユーザーに不正な値がある時" do
+        subject { build(:reaction, user_id: attribute) }
+
+        context "存在しない時" do
+          let(:attribute) { nil }
+          it { is_expected.to be_invalid }
+        end
+
+        context "空である時" do
+          let(:attribute) { '' }
+          it { is_expected.to be_invalid }
+        end
+      end
+
+      context "イベント候補日に不正な値がある時" do
+        subject { build(:reaction, event_date_id: attribute) }
+
+        context "存在しない時" do
+          let(:attribute) { nil }
+          it { is_expected.to be_invalid }
+        end
+
+        context "空である時" do
+          let(:attribute) { '' }
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,4 +20,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include FactoryBot::Syntax::Methods
+
+  config.include SessionTestHelper
 end


### PR DESCRIPTION
# 目的
本アプリで作成されたイベントの候補日に対して（URLを知っている）ログイン済みユーザーが反応（○、△、×）を返すた際に利用されるモデルです。

参考までにテーブル設計の画像を添付しておきます。
![img_8621](https://user-images.githubusercontent.com/39050027/41700614-e70fac62-7563-11e8-8b07-5dcd47a3db79.JPG)

# 内容
* Reactionモデルを追加し、他のテーブルとの関連づけを宣言しました。
* 全てのマイグレーションファイルで外部キー参照をするカラムに`foreign_key: true`を加えて外部キー制約をかけるようにしました。
* 複数ユーザーがいる前提（イベントを作ったユーザーと回答するユーザーが違うなど）でテストをする必要が出てきたので、Factory BotのUserモデルのテストデータの定義を変えました。

また、このPRは#9 や#10 のPRのブランチから切った最新のブランチを使って修正を加えていますので、本PRで追加したコミットは[Add reaction model](https://github.com/masayoshi-toku/nomikai_adjustment/pull/11/commits/50e608c8530ccd192260d5d3001fcfa82f9d8f19)からになります。

レビューの方、よろしくお願いします。
