### PR TITLE
Event作成失敗時に出るエラーの修正

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,9 +21,11 @@ class EventsController < ApplicationController
   def create
     @event_form = EventForm.new(event_params.merge({ user: current_user }))
 
-    if @event_form.event = @event_form.create
+    if @event_form.valid?
+      @event_form.event = @event_form.create
       redirect_to event_path(@event_form.event.url_path), notice: 'Event was successfully created.'
     else
+      @event_form.event = Event.new
       render :new
     end
   end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe EventsController, type: :controller do
 
       context "不正なパラメーターの場合" do
         subject { post :create, params: { event_form: attributes } }
+        render_views
 
         context "タイトルが空の場合" do
           let(:attributes) { { title: '', event_dates_text: "2018/06/18\r\n2018/06/19\r\n2018/06/20" } }

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -118,6 +118,13 @@ RSpec.describe EventsController, type: :controller do
 
           it { is_expected.to render_template(:new) }
         end
+
+        context "タイトルと日付が空の場合" do
+          before { log_in(user) }
+          let(:attributes) { { title: '', event_dates_text: '' } }
+
+          it { is_expected.to render_template(:new) }
+        end
       end
     end
 


### PR DESCRIPTION
# 目的
Event作成失敗時に出るエラーの修正

# 内容
Event作成失敗時に出るエラーを以下の二つの観点から修正しました。
- Event作成が失敗してもEventモデルのインスタンスをフォームに渡せるようにする
- エラーメッセージが出るようにする