### PR TITLE
Event作成時のuniqunessのエラーの修正

### DIFF
--- a/app/models/event_form.rb
+++ b/app/models/event_form.rb
@@ -21,6 +21,6 @@ class EventForm
     end
 
     def event_dates
-      event_dates_text.split(/[\r\n]+|\r+|\n+/).inject(Array.new) {|array, value| array.push({ event_date: value })}
+      event_dates_text.split(/[\r\n]+|\r+|\n+/).uniq.inject(Array.new) {|array, value| array.push({ event_date: value })}
     end
 end

--- a/spec/models/event_form_spec.rb
+++ b/spec/models/event_form_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe EventForm, type: :model do
 
         it { is_expected.to be_truthy }
       end
+
+      context "日付に同じテキストが含まれていた場合" do
+        let(:attributes) { { title: "第一回飲み会", event_dates_text: "2018/06/18\r\n2018/06/18\r\n2018/06/20" } }
+
+        it { expect { subject }.to change { Event.count }.by(1) }
+        it { expect { subject }.to change { EventDate.count }.by(2) }
+      end
     end
 
     context "不正な値の場合" do


### PR DESCRIPTION
# 目的
#15 に対応し、エラーを修正する

# 内容
フォームの内容をsplitでparseした後に`uniq`メソッドで同じ文字は削除するようにしました。