### PR TITLE
回答編集ページの追加

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -2,11 +2,11 @@ class ReactionsController < ApplicationController
   before_action :set_event, only: [:new, :edit, :create]
 
   def new
-    initialize_form_object
+    initialize_reaction_form_object
   end
 
   def edit
-    initialize_form_object
+    initialize_reaction_form_object
   end
 
   def create
@@ -19,7 +19,7 @@ class ReactionsController < ApplicationController
   end
 
   private
-    def initialize_form_object
+    def initialize_reaction_form_object
       if @event
         @reaction_form = ReactionForm.new(reaction: Reaction.new)
       else

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,17 +1,12 @@
 class ReactionsController < ApplicationController
-  before_action :set_reaction, only: [:edit, :update, :destroy]
-  before_action :set_event, only: [:new, :create]
+  before_action :set_event, only: [:new, :edit, :create]
 
   def new
-    if @event
-      @reaction_form = ReactionForm.new(reaction: Reaction.new)
-    else
-      redirect_to root_url
-    end
+    initialize_form_object
   end
 
   def edit
-    exist_or_redirect(@reaction)
+    initialize_form_object
   end
 
   def create
@@ -23,17 +18,13 @@ class ReactionsController < ApplicationController
     end
   end
 
-  def destroy
-    if @reaction&.destroy
-      redirect_to event_url(@reaction.event), notice: '回答を削除しました。'
-    else
-      redirect_to root_url, notice: '回答を削除できませんでした'
-    end
-  end
-
   private
-    def set_reaction
-      @reaction = Reaction.find_by(id: params[:id])
+    def initialize_form_object
+      if @event
+        @reaction_form = ReactionForm.new(reaction: Reaction.new)
+      else
+        redirect_to root_url, notice: 'イベントが存在しません。'
+      end
     end
 
     def set_event
@@ -42,11 +33,5 @@ class ReactionsController < ApplicationController
 
     def reaction_params
       params.require(:reaction_form).permit(answer: {})
-    end
-
-    def exist_or_redirect(reaction)
-      unless reaction
-        redirect_back(fallback_location: root_path, notice: 'この回答は存在しません。')
-      end
     end
 end

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -14,7 +14,7 @@ class ReactionsController < ApplicationController
     if @reaction_form.create
       redirect_to event_url(@event.url_path), notice: '出席の登録に成功しました。'
     else
-      redirect_to new_event_reaction_url(@event.url_path), notice: '出席の登録に失敗しました。'
+      redirect_to new_event_reactions_url(@event.url_path), notice: '出席の登録に失敗しました。'
     end
   end
 

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -21,7 +21,7 @@ class ReactionsController < ApplicationController
   private
     def initialize_reaction_form_object
       if @event
-        @reaction_form = ReactionForm.new(reaction: Reaction.new)
+        @reaction_form = ReactionForm.new
       else
         redirect_to root_url, notice: 'イベントが存在しません。'
       end

--- a/app/models/reaction_form.rb
+++ b/app/models/reaction_form.rb
@@ -1,7 +1,7 @@
 class ReactionForm
   include ActiveModel::Model
 
-  attr_accessor :user, :reaction, :answer
+  attr_accessor :user, :answer
 
   validates :answer, presence: true
   validates :user, presence: true

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -23,8 +23,9 @@
           %td 0
           %td 0
 
-= link_to '出席を入力する', new_event_reaction_path(@event.url_path)
+- if @event.answerers.include?(@current_user.name)
+  = link_to '出席を修正する', edit_event_reaction_path(@event.url_path)
+- else
+  = link_to '出席を登録する', new_event_reaction_path(@event.url_path)
 %input{ type: 'text', size: 25, onfocus: 'this.select();', value: event_url(@event.url_path) }
-= link_to 'Edit', edit_event_path(@event.url_path)
-|
 = link_to 'Back', events_path

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -23,7 +23,7 @@
           %td 0
           %td 0
 
-- if @event.answerers.include?(@current_user.name)
+- if @event.answerers&.include?(@current_user.name)
   = link_to '出席を修正する', edit_event_reactions_path(@event.url_path)
 - else
   = link_to '出席を登録する', new_event_reactions_path(@event.url_path)

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -24,8 +24,8 @@
           %td 0
 
 - if @event.answerers.include?(@current_user.name)
-  = link_to '出席を修正する', edit_event_reaction_path(@event.url_path)
+  = link_to '出席を修正する', edit_event_reactions_path(@event.url_path)
 - else
-  = link_to '出席を登録する', new_event_reaction_path(@event.url_path)
+  = link_to '出席を登録する', new_event_reactions_path(@event.url_path)
 %input{ type: 'text', size: 25, onfocus: 'this.select();', value: event_url(@event.url_path) }
 = link_to 'Back', events_path

--- a/app/views/reactions/_edit_form.html.haml
+++ b/app/views/reactions/_edit_form.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: reaction_form, url: event_reaction_path(event_url_path), method: :patch, local: true) do |form|
+= form_with(model: reaction_form, url: event_reactions_path(event_url_path), method: :patch, local: true) do |form|
   - if reaction_form.reaction.errors.any?
     #error_explanation
       %h2= "#{pluralize(reaction_form.reaction.errors.count, "error")} prohibited this reaction from being saved:"

--- a/app/views/reactions/_edit_form.html.haml
+++ b/app/views/reactions/_edit_form.html.haml
@@ -1,9 +1,9 @@
 = form_with(model: reaction_form, url: event_reactions_path(event_url_path), method: :patch, local: true) do |form|
-  - if reaction_form.reaction.errors.any?
+  - if reaction_form.errors.any?
     #error_explanation
-      %h2= "#{pluralize(reaction_form.reaction.errors.count, "error")} prohibited this reaction from being saved:"
+      %h2= "#{pluralize(reaction_form.errors.count, "error")} prohibited this reaction from being saved:"
       %ul
-        - reaction_form.reaction.errors.full_messages.each do |message|
+        - reaction_form.errors.full_messages.each do |message|
           %li= message
   %table{ border: 1 }
     %thead

--- a/app/views/reactions/_edit_form.html.haml
+++ b/app/views/reactions/_edit_form.html.haml
@@ -1,10 +1,4 @@
 = form_with(model: reaction_form, url: event_reactions_path(event_url_path), method: :patch, local: true) do |form|
-  - if reaction_form.errors.any?
-    #error_explanation
-      %h2= "#{pluralize(reaction_form.errors.count, "error")} prohibited this reaction from being saved:"
-      %ul
-        - reaction_form.errors.full_messages.each do |message|
-          %li= message
   %table{ border: 1 }
     %thead
       %tr

--- a/app/views/reactions/_edit_form.html.haml
+++ b/app/views/reactions/_edit_form.html.haml
@@ -1,0 +1,22 @@
+= form_with(model: reaction_form, url: event_reaction_path(event_url_path), method: :patch, local: true) do |form|
+  - if reaction_form.reaction.errors.any?
+    #error_explanation
+      %h2= "#{pluralize(reaction_form.reaction.errors.count, "error")} prohibited this reaction from being saved:"
+      %ul
+        - reaction_form.reaction.errors.full_messages.each do |message|
+          %li= message
+  %table{ border: 1 }
+    %thead
+      %tr
+        %th 日程
+        %th ◯
+        %th △
+        %th ×
+    - event_dates.each do |event_date|
+      %tr
+        %th= event_date.event_date
+        %td= form.radio_button "answer[#{event_date.id}]", 1
+        %td= form.radio_button "answer[#{event_date.id}]", 2, { checked: true }
+        %td= form.radio_button "answer[#{event_date.id}]", 3
+  .actions
+    = form.submit 'Save'

--- a/app/views/reactions/_form.html.haml
+++ b/app/views/reactions/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: reaction_form, url: event_reactions_path(event_url_path), local: true) do |form|
+= form_with(model: reaction_form, url: event_reaction_path(@event.url_path), local: true) do |form|
   - if reaction_form.reaction.errors.any?
     #error_explanation
       %h2= "#{pluralize(reaction_form.reaction.errors.count, "error")} prohibited this reaction from being saved:"

--- a/app/views/reactions/_form.html.haml
+++ b/app/views/reactions/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: reaction_form, url: event_reaction_path(@event.url_path), local: true) do |form|
+= form_with(model: reaction_form, url: event_reactions_path(@event.url_path), local: true) do |form|
   - if reaction_form.reaction.errors.any?
     #error_explanation
       %h2= "#{pluralize(reaction_form.reaction.errors.count, "error")} prohibited this reaction from being saved:"

--- a/app/views/reactions/_form.html.haml
+++ b/app/views/reactions/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: reaction_form, url: event_reactions_path(@event.url_path), local: true) do |form|
+= form_with(model: reaction_form, url: event_reactions_path(event_url_path), local: true) do |form|
   - if reaction_form.reaction.errors.any?
     #error_explanation
       %h2= "#{pluralize(reaction_form.reaction.errors.count, "error")} prohibited this reaction from being saved:"

--- a/app/views/reactions/_form.html.haml
+++ b/app/views/reactions/_form.html.haml
@@ -1,10 +1,4 @@
 = form_with(model: reaction_form, url: event_reactions_path(@event.url_path), local: true) do |form|
-  - if reaction_form.reaction.errors.any?
-    #error_explanation
-      %h2= "#{pluralize(reaction_form.reaction.errors.count, "error")} prohibited this reaction from being saved:"
-      %ul
-        - reaction_form.reaction.errors.full_messages.each do |message|
-          %li= message
   %table{ border: 1 }
     %thead
       %tr

--- a/app/views/reactions/edit.html.haml
+++ b/app/views/reactions/edit.html.haml
@@ -1,7 +1,4 @@
 %h1 Editing reaction
 
-= render 'form'
-
-= link_to 'Show', @reaction
-\|
-= link_to 'Back', reactions_path
+= render 'edit_form', reaction_form: @reaction_form, event_dates: @event.event_dates, event_url_path: @event.url_path
+= link_to 'Back', event_path(@event)

--- a/app/views/reactions/edit.html.haml
+++ b/app/views/reactions/edit.html.haml
@@ -1,4 +1,4 @@
 %h1 Editing reaction
 
 = render 'edit_form', reaction_form: @reaction_form, event_dates: @event.event_dates, event_url_path: @event.url_path
-= link_to 'Back', event_path(@event)
+= link_to 'Back', event_path(@event.url_path)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@ Rails.application.routes.draw do
   root to: 'sessions#new'
   resources :users, only: [:index, :show, :destroy]
   resources :events, param: 'url_path' do
-    resources :reactions, except: [:index, :show]
+    resource :reaction
   end
-  get "/auth/google_oauth2", as: "google_auth"
+  get '/auth/google_oauth2', as: 'google_auth'
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/login', to: 'sessions#new'
   delete '/logout', to: 'sessions#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root to: 'sessions#new'
   resources :users, only: [:index, :show, :destroy]
   resources :events, param: 'url_path' do
-    resource :reaction
+    resource :reactions
   end
   get '/auth/google_oauth2', as: 'google_auth'
   get '/auth/:provider/callback', to: 'sessions#create'

--- a/spec/controllers/reactions_controller_spec.rb
+++ b/spec/controllers/reactions_controller_spec.rb
@@ -13,17 +13,15 @@ RSpec.describe ReactionsController, type: :controller do
   end
 
   describe "GET #edit" do
-    subject { get :edit, params: { event_url_path: url_path, id: id } }
+    subject { get :edit, params: { event_url_path: url_path } }
 
-    context "回答が存在する場合" do
+    context "イベントが存在する場合" do
       let(:url_path) { event.url_path }
-      let(:id) { reaction.id }
       it { is_expected.to be_successful }
     end
 
-    context "回答が存在しない場合" do
-      let(:url_path) { event.url_path }
-      let(:id) { reaction.id + 1 }
+    context "イベントが存在しない場合" do
+      let(:url_path) { '' }
       it { is_expected.to redirect_to root_path }
     end
   end
@@ -50,24 +48,6 @@ RSpec.describe ReactionsController, type: :controller do
       let(:attributes) { { answer: { "#{event_date.id}": '10' } } }
 
       it { is_expected.to redirect_to new_event_reaction_url(event.url_path) }
-    end
-  end
-
-  describe "DELETE #destroy" do
-    subject { delete :destroy, params: { event_url_path: url_path, id: id } }
-    before { reaction }
-
-    context "回答が存在する場合" do
-      let(:url_path) { event.url_path }
-      let(:id) { reaction.id }
-      it { expect{ subject }.to change{ Reaction.count }.by(-1) }
-      it { is_expected.to redirect_to event }
-    end
-
-    context "回答が存在しない場合" do
-      let(:url_path) { event.url_path }
-      let(:id) { 10 }
-      it { is_expected.to redirect_to root_url }
     end
   end
 end

--- a/spec/controllers/reactions_controller_spec.rb
+++ b/spec/controllers/reactions_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ReactionsController, type: :controller do
     context "不正な値の場合" do
       let(:attributes) { { answer: { "#{event_date.id}": '10' } } }
 
-      it { is_expected.to redirect_to new_event_reaction_url(event.url_path) }
+      it { is_expected.to redirect_to new_event_reactions_url(event.url_path) }
     end
   end
 end


### PR DESCRIPTION
# 目的
回答編集ページの追加

# 内容
ユーザーが一度回答した後に回答をし直すためのeditアクションと回答編集ページを追加しました。
変更点としては以下の通りです。
- ネストしたルーティングのうち、Reactionクラスは`resources`ではなく`resource`としました。
- ルーティングのパラメーターをカスタムした場合のpolymorphic_pathの扱いが難しかったため、納期も鑑みてformパーシャルを使い回すのではなく、edit_formパーシャルを作成して使うことにしました。
- （今更かもしれませんが）destroyアクションはまだ実装していないので、テストと共に削除しました。

このブランチから追加したコミットは[Remove destroy action and add initalize form object method](https://github.com/masayoshi-toku/nomikai_adjustment/pull/19/commits/b58096935ba1e903ba6c525d852b3bfe61196b60)です。

コメントの方をよろしくお願いします。