### PR TITLE
回答削除機能の追加

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,5 +1,5 @@
 class ReactionsController < ApplicationController
-  before_action :set_event, only: [:new, :edit, :create, :update]
+  before_action :set_event
 
   def new
     initialize_reaction_form_object
@@ -24,6 +24,19 @@ class ReactionsController < ApplicationController
       redirect_to event_url(@event.url_path), notice: '出席の更新に成功しました。'
     else
       redirect_to edit_event_reactions_path(@event.url_path), notice: '出席の更新に失敗しました。'
+    end
+  end
+
+  def destroy
+    if @event
+      event_reactions = current_user.reactions.where(event_date_id: @event.event_dates.ids)
+      if Reaction.destroy(event_reactions.ids)
+        redirect_to event_url(@event.url_path), notice: '出席の削除に成功しました。'
+      else
+        redirect_to event_url(@event.url_path), notice: '出席の削除に失敗しました。'
+      end
+    else
+      redirect_to root_path, notice: '出席の削除に失敗しました。'
     end
   end
 

--- a/app/views/reactions/_edit_form.html.haml
+++ b/app/views/reactions/_edit_form.html.haml
@@ -14,3 +14,4 @@
         %td= form.radio_button "answer[#{event_date.id}]", 3
   .actions
     = form.submit 'Save'
+  = link_to 'Destroy', event_reactions_path(event_url_path), method: :delete, data: { confirm: 'Are you sure?' }

--- a/spec/controllers/reactions_controller_spec.rb
+++ b/spec/controllers/reactions_controller_spec.rb
@@ -81,4 +81,25 @@ RSpec.describe ReactionsController, type: :controller do
       it { is_expected.to redirect_to edit_event_reactions_path(event.url_path) }
     end
   end
+
+  describe "DELETE #destroy" do
+    subject { delete :destroy, params: { event_url_path: url_path } }
+    before do
+      log_in(user)
+      reaction
+    end
+
+    context "正しい値の場合" do
+      let(:url_path) { event.url_path }
+
+      it { expect{subject}.to change{ Reaction.count }.by(-1) }
+      it { is_expected.to redirect_to event_url(url_path) }
+    end
+
+    context "不正な値の場合" do
+      let(:url_path) { '' }
+
+      it { is_expected.to redirect_to root_path }
+    end
+  end
 end


### PR DESCRIPTION
# 目的
回答削除機能の追加

# 内容
ユーザーが自分が回答した内容を削除できるようにしました。追加したコミットは[Add delete action](https://github.com/masayoshi-toku/nomikai_adjustment/commit/aed2ae0d758b0b7de919a3f1a9ea4f6cc28813ba)からです。

# 注意点・懸念点
まず、予め了承して欲しい点について書いておきます。#20 にもあるように、reactions controllerのupdateアクションやdestroyアクションはログインしたユーザーを利用するような機能になっていますが、それぞれのアクションにbefore actionでログインチェックをさせていません。

この点に関しては次のPRで一括で修正しますので、テストケースからも外しています。ご了承頂けるとありがたいです。

次に懸念点ですが、reactions#destroyアクションの内容についてです。`destroy_all`だと成功した場合にも返り値は削除したオブジェクト（の配列）になってしまうので、真偽値を返すdestroyアクションにidsを渡すことで処理させています。

しかし、条件文にモデルを明記する`Reaction.destroy`というのが何となく良くない気がしています。何かアドバイスがあれば、よろしくお願いします。

【追記】
@matsuhisa さん、レビューの方をよろしくお願いします。