### PR TITLE
Reactionリソースにアクセスする際のログインの義務化

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -14,10 +14,6 @@ class EventsController < ApplicationController
     @event_form = EventForm.new(event: Event.new)
   end
 
-  def edit
-    exist_or_redirect(@event)
-  end
-
   def create
     @event_form = EventForm.new(event_params.merge({ user: current_user }))
 

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,5 +1,5 @@
 class ReactionsController < ApplicationController
-  before_action :set_event
+  before_action :set_event, :logged_in?
 
   def new
     initialize_reaction_form_object

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -60,35 +60,6 @@ RSpec.describe EventsController, type: :controller do
     end
   end
 
-  describe "GET #edit" do
-    subject { get :edit, params: params }
-
-    context "ログイン済みの場合" do
-      before do
-        event
-        log_in(event.user)
-      end
-
-      context "イベントが存在する場合" do
-        let(:params) { { url_path: event.url_path } }
-
-        it { is_expected.to be_successful }
-      end
-
-      context "イベントが存在しない場合" do
-        let(:params) { { url_path: 'abc' } }
-
-        it { is_expected.to redirect_to events_url }
-      end
-    end
-
-    context "ログインしていない場合" do
-      let(:params) { { url_path: event.url_path } }
-
-      it { is_expected.to redirect_to root_url }
-    end
-  end
-
   describe "POST #create" do
     context "ログイン済みの場合" do
       before do

--- a/spec/controllers/reactions_controller_spec.rb
+++ b/spec/controllers/reactions_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ReactionsController, type: :controller do
   let(:reaction) { create(:reaction, user: user, event_date: event_date) }
 
   describe "GET #new" do
+    before { log_in(user) }
     subject { get :new, params: { event_url_path: url_path } }
     let(:url_path) { event.url_path }
     it { is_expected.to be_successful }
@@ -15,89 +16,120 @@ RSpec.describe ReactionsController, type: :controller do
   describe "GET #edit" do
     subject { get :edit, params: { event_url_path: url_path } }
 
-    context "イベントが存在する場合" do
-      let(:url_path) { event.url_path }
-      it { is_expected.to be_successful }
+    context "ログイン済みの場合" do
+      before { log_in(user) }
+
+      context "イベントが存在する場合" do
+        let(:url_path) { event.url_path }
+        it { is_expected.to be_successful }
+      end
+
+      context "イベントが存在しない場合" do
+        let(:url_path) { '' }
+        it { is_expected.to redirect_to root_path }
+      end
     end
 
-    context "イベントが存在しない場合" do
-      let(:url_path) { '' }
+    context "ログインしていない場合" do
+      let(:url_path) { event.url_path }
       it { is_expected.to redirect_to root_path }
     end
   end
 
   describe "POST #create" do
     subject { post :create, params: { reaction_form: attributes, event_url_path: event.url_path } }
+    before { event_date }
 
-    before do
-      event_date
-      log_in(user)
-    end
+    context "ログイン済みの場合" do
+      before { log_in(user) }
 
-    context "正しい値の場合" do
-      let(:attributes) { { answer: { "#{event_date.id}": '3' } } }
-      it { expect{ subject }.to change{ Reaction.count }.by(1) }
+      context "正しい値の場合" do
+        let(:attributes) { { answer: { "#{event_date.id}": '3' } } }
+        it { expect{ subject }.to change{ Reaction.count }.by(1) }
 
-      it "イベント詳細ページへリダイレクトする" do
-        event_url_path = event.url_path
-        expect(subject).to redirect_to event_path(event_url_path)
+        it "イベント詳細ページへリダイレクトする" do
+          event_url_path = event.url_path
+          expect(subject).to redirect_to event_path(event_url_path)
+        end
+      end
+
+      context "不正な値の場合" do
+        let(:attributes) { { answer: { "#{event_date.id}": '10' } } }
+
+        it { is_expected.to redirect_to new_event_reactions_url(event.url_path) }
       end
     end
 
-    context "不正な値の場合" do
-      let(:attributes) { { answer: { "#{event_date.id}": '10' } } }
-
-      it { is_expected.to redirect_to new_event_reactions_url(event.url_path) }
+    context "ログインしていない場合" do
+      let(:attributes) { { answer: { "#{event_date.id}": '3' } } }
+      it { is_expected.to redirect_to root_path }
     end
   end
 
   describe "PUT #update" do
-    before do
-      reaction
-      log_in(user)
-      put :update, params: { reaction_form: attributes, event_url_path: event.url_path }
+    before { reaction }
+
+    context "ログイン済みの場合" do
+      before do
+        log_in(user)
+        put :update, params: { reaction_form: attributes, event_url_path: event.url_path }
+      end
+
+      context "正しい値の場合" do
+        before { old_status }
+        let(:old_status) { reaction.status }
+        let(:attributes) { { answer: { "#{event_date.id}": '3' } } }
+        let(:updated_reaction) { Reaction.find_by(id: reaction.id) }
+
+        it :aggregate_failures do
+          expect(updated_reaction.status).not_to eq old_status
+          expect(updated_reaction.status).to eq 3
+        end
+
+        it "イベント詳細ページへリダイレクトする" do
+          event_url_path = event.url_path
+          expect(response).to redirect_to event_path(event_url_path)
+        end
+      end
+
+      context "不正な値の場合" do
+        let(:attributes) { { answer: { "#{event_date.id}": '10' } } }
+
+        it { is_expected.to redirect_to edit_event_reactions_path(event.url_path) }
+      end
     end
 
-    context "正しい値の場合" do
-      before { old_status }
-      let(:old_status) { reaction.status }
+    context "ログインしていない場合" do
+      before { put :update, params: { reaction_form: attributes, event_url_path: event.url_path } }
       let(:attributes) { { answer: { "#{event_date.id}": '3' } } }
-      let(:updated_reaction) { Reaction.find_by(id: reaction.id) }
 
-      it :aggregate_failures do
-        expect(updated_reaction.status).not_to eq old_status
-        expect(updated_reaction.status).to eq 3
-      end
-
-      it "イベント詳細ページへリダイレクトする" do
-        event_url_path = event.url_path
-        expect(response).to redirect_to event_path(event_url_path)
-      end
-    end
-
-    context "不正な値の場合" do
-      let(:attributes) { { answer: { "#{event_date.id}": '10' } } }
-
-      it { is_expected.to redirect_to edit_event_reactions_path(event.url_path) }
+      it { is_expected.to redirect_to root_path }
     end
   end
 
   describe "DELETE #destroy" do
     subject { delete :destroy, params: { event_url_path: url_path } }
-    before do
-      log_in(user)
-      reaction
+    before { reaction }
+
+    context "ログイン済みの場合" do
+      before { log_in(user) }
+
+      context "正しい値の場合" do
+        let(:url_path) { event.url_path }
+
+        it { expect{subject}.to change{ Reaction.count }.by(-1) }
+        it { is_expected.to redirect_to event_url(url_path) }
+      end
+
+      context "不正な値の場合" do
+        let(:url_path) { '' }
+
+        it { is_expected.to redirect_to root_path }
+      end
     end
 
-    context "正しい値の場合" do
+    context "ログインしていない場合" do
       let(:url_path) { event.url_path }
-
-      it { expect{subject}.to change{ Reaction.count }.by(-1) }
-      it { is_expected.to redirect_to event_url(url_path) }
-    end
-
-    context "不正な値の場合" do
-      let(:url_path) { '' }
 
       it { is_expected.to redirect_to root_path }
     end


### PR DESCRIPTION
# 目的
Reactionリソースにアクセスする際のログインの義務化

# 内容
#21 にも書いた通り、reactions controllerの各アクションでログインを必須にしていなかったのでbefore actionに`logged_in?`メソッドを追加してログインを必須にしました。それを受けて、テストもログイン済みのケースと未ログインのケースに分けて修正しました。

このブランチからの追加コミットは[Remove edit action for events controller](https://github.com/masayoshi-toku/nomikai_adjustment/commit/76c7cf32a240d9889d66ebb6f4737a4e7445a7b9)から始まっています。

確認の方、よろしくお願いします。

【追記】
@matsuhisa さん、レビューの方をよろしくお願いします。