### PR TITLE
イベント編集ページの追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -14,6 +14,10 @@ class EventsController < ApplicationController
     @event_form = EventForm.new(event: Event.new)
   end
 
+  def edit
+    @event_form = EventForm.new(event: @event)
+  end
+
   def create
     @event_form = EventForm.new(event_params.merge({ user: current_user }))
 

--- a/app/views/events/_edit_form.html.haml
+++ b/app/views/events/_edit_form.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: event_form, url: event_path(@event.url_path), method: :patch, local: true) do |form|
+= form_with(model: event_form, url: event_path(event_url_path), method: :patch, local: true) do |form|
   - if event_form.errors.any?
     #error_explanation
       %h2

--- a/app/views/events/_edit_form.html.haml
+++ b/app/views/events/_edit_form.html.haml
@@ -1,0 +1,22 @@
+= form_with(model: event_form, url: event_path(@event.url_path), method: :patch, local: true) do |form|
+  - if event_form.errors.any?
+    #error_explanation
+      %h2
+        = pluralize(event_form.errors.count, "error")
+        prohibited this event_form from being saved:
+      %ul
+        - event_form.errors.full_messages.each do |message|
+          %li= message
+  .field
+    = form.label 'イベント名'
+    = form.text_field :title, value: @event.title
+  %p 削除する項目
+  - event_dates.each do |event_date|
+    .field
+      = form.check_box "event_dates[#{event_date.event_date}]"
+      = event_date.event_date
+  .field
+    = form.label '追加する候補'
+    = form.text_area :event_dates_text, size: '30x10', placeholder: '候補日程／日時を入力してください。候補の区切りは改行で判断されます。'
+  .actions
+    = form.submit '更新'

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -1,5 +1,5 @@
 %h1 Editing Event
-= render 'edit_form', event_form: @event_form, event_dates: @event.event_dates
+= render 'edit_form', event_form: @event_form, event_dates: @event.event_dates, event_url_path: @event.url_path
 = link_to 'Show', @event
 |
 = link_to 'Back', events_path

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -1,5 +1,5 @@
 %h1 Editing Event
-= render 'form', event: @event
+= render 'edit_form', event_form: @event_form, event_dates: @event.event_dates
 = link_to 'Show', @event
 |
 = link_to 'Back', events_path

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -12,7 +12,5 @@
           %td= event.user_id
           %td= event.title
           %td= link_to 'Show', event_path(event.url_path)
-          %td= link_to 'Edit', edit_event_path(event.url_path)
-          %td= link_to 'Destroy', event_path(event.url_path), method: :delete, data: { confirm: 'Are you sure?' }
 %br/
 = link_to 'New Event', new_event_path

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -27,5 +27,10 @@
   = link_to '出席を修正する', edit_event_reactions_path(@event.url_path)
 - else
   = link_to '出席を登録する', new_event_reactions_path(@event.url_path)
-%input{ type: 'text', size: 25, onfocus: 'this.select();', value: event_url(@event.url_path) }
+- if @event.user == @current_user
+  \|
+  = link_to '編集', edit_event_path(@event.url_path)
+\|
 = link_to 'Back', events_path
+%br
+%input{ type: 'text', size: 25, onfocus: 'this.select();', value: event_url(@event.url_path) }

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -60,6 +60,27 @@ RSpec.describe EventsController, type: :controller do
     end
   end
 
+  describe "GET #edit" do
+    subject { get :edit, params: { url_path: url_path } }
+
+    context "ログイン済みの場合" do
+      before do
+        event
+        log_in(user)
+      end
+
+      context "イベントが存在する場合" do
+        let(:url_path) { event.url_path }
+        it { is_expected.to be_successful }
+      end
+    end
+
+    context "ログインしていない場合" do
+      let(:url_path) { event.url_path }
+      it { is_expected.to redirect_to root_url }
+    end
+  end
+
   describe "POST #create" do
     context "ログイン済みの場合" do
       before do


### PR DESCRIPTION
# 目的
イベント編集ページの追加

# 内容
イベント編集ページを追加しました。イベント編集ページでは、イベント名と日程の削除や追加などが行われる予定です。このブランチから追加されたコミットは[Remove inappropriate links](https://github.com/masayoshi-toku/nomikai_adjustment/commit/e945ea9049d3333eabf7c499000c23c0dcda159b)からです。

確認の方、よろしくお願いします。

【追記】
@matsuhisa さん、レビューの方をよろしくお願いします。