### PR TITLE
イベントの更新機能の作成

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,13 +1,12 @@
 class EventsController < ApplicationController
   before_action :logged_in?, except: [:index]
-  before_action :set_event, except: [:index, :new, :create]
+  before_action :set_event, :exist_or_redirect, except: [:index, :new, :create]
 
   def index
     @events = Event.all
   end
 
   def show
-    exist_or_redirect(@event)
   end
 
   def new
@@ -55,9 +54,9 @@ class EventsController < ApplicationController
       @event = Event.find_by(url_path: params[:url_path])
     end
 
-    def exist_or_redirect(event)
-      unless event
-        redirect_to events_url
+    def exist_or_redirect
+      unless @event.present?
+        redirect_to events_url and return
       end
     end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -30,10 +30,11 @@ class EventsController < ApplicationController
   end
 
   def update
-    if @event&.update(event_params)
-      redirect_to @event, notice: 'Event was successfully updated.'
+    @event_form = EventForm.new(edit_event_params.merge({ user: current_user, event: @event }))
+    if @event_form.update
+      redirect_to event_path(@event_form.event.url_path), notice: 'イベントの更新に成功しました。'
     else
-      render :edit
+      redirect_to edit_event_url(@event.url_path), notice: 'イベントの更新に失敗しました。'
     end
   end
 
@@ -48,6 +49,10 @@ class EventsController < ApplicationController
   private
     def event_params
       params.require(:event_form).permit(:title, :event_dates_text)
+    end
+
+    def edit_event_params
+      params.require(:event_form).permit(:title, :event_dates_text, deletable_event_dates: {})
     end
 
     def set_event

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -61,7 +61,7 @@ class EventsController < ApplicationController
 
     def exist_or_redirect
       unless @event.present?
-        redirect_to events_url and return
+        redirect_to events_url
       end
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,10 +6,10 @@ class Event < ApplicationRecord
   validates :url_path, presence: true, uniqueness: true
 
   def answerers
-    first_event_date = event_dates.first
-    if first_event_date
-      @answerers = first_event_date.reactions.order(:id).map { |reaction| reaction.user.name }
+    if event_dates.present?
+      @answerers = []
+      event_dates.each { |event_date| @answerers |= event_date.reactions.map { |reaction| reaction.user.name } }
       @answerers
-    end  
+    end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,9 +7,7 @@ class Event < ApplicationRecord
 
   def answerers
     if event_dates.present?
-      @answerers = []
-      event_dates.each { |event_date| @answerers |= event_date.reactions.map { |reaction| reaction.user.name } }
-      @answerers
+      event_dates.inject(Array.new) { |answerers, event_date| answerers |= event_date.reactions.map { |reaction| reaction.user.name } }
     end
   end
 end

--- a/app/models/event_form.rb
+++ b/app/models/event_form.rb
@@ -1,7 +1,7 @@
 class EventForm
   include ActiveModel::Model
 
-  attr_accessor :user, :event, :title, :event_dates_text
+  attr_accessor :user, :event, :title, :event_dates_text, :deletable_event_dates
 
   validates :title, presence: true, length: { maximum: 100 }
   validates :event_dates_text, :user, presence: true
@@ -11,7 +11,37 @@ class EventForm
     user.events.create(nested_params)
   end
 
+  def update
+    update_reaction
+  end
+
   private
+    def update_reaction
+      ActiveRecord::Base.transaction do
+        if title.present?
+          event.update!(title: title)
+        end
+
+        if deletable_event_dates.present?
+          checked_deletable_event_dates = deletable_event_dates.delete_if { |key, value| value == '0' }
+          if checked_deletable_event_dates.present?
+            event.event_dates.where(id: checked_deletable_event_dates.keys).each(&:destroy!)
+          end
+        end
+
+        if event_dates_text.present?
+          event_dates.each do |event_date|
+            event.event_dates.new(event_date)
+          end
+          event.save!
+        end
+
+        return true
+      rescue ActiveRecord::RecordNotDestroyed, ActiveRecord::RecordInvalid
+        return false
+      end
+    end
+
     def nested_params
       { title: title, url_path: url_path, event_dates_attributes: event_dates }
     end

--- a/app/models/event_form.rb
+++ b/app/models/event_form.rb
@@ -18,27 +18,36 @@ class EventForm
   private
     def update_reaction
       ActiveRecord::Base.transaction do
-        if title.present?
-          event.update!(title: title)
-        end
-
-        if deletable_event_dates.present?
-          checked_deletable_event_dates = deletable_event_dates.delete_if { |key, value| value == '0' }
-          if checked_deletable_event_dates.present?
-            event.event_dates.where(id: checked_deletable_event_dates.keys).each(&:destroy!)
-          end
-        end
-
-        if event_dates_text.present?
-          event_dates.each do |event_date|
-            event.event_dates.new(event_date)
-          end
-          event.save!
-        end
-
+        title_update
+        delete_event_dates
+        update_or_create_event_dates
         return true
       rescue ActiveRecord::RecordNotDestroyed, ActiveRecord::RecordInvalid
         return false
+      end
+    end
+
+    def title_update
+      if title.present?
+        event.update!(title: title)
+      end
+    end
+
+    def delete_event_dates
+      if deletable_event_dates.present?
+        checked_deletable_event_dates = deletable_event_dates.delete_if { |key, value| value == '0' }
+        if checked_deletable_event_dates.present?
+          event.event_dates.where(id: checked_deletable_event_dates.keys).each(&:destroy!)
+        end
+      end
+    end
+
+    def update_or_create_event_dates
+      if event_dates_text.present?
+        event_dates.each do |event_date|
+          event.event_dates.new(event_date)
+        end
+        event.save!
       end
     end
 

--- a/app/views/events/_edit_form.html.haml
+++ b/app/views/events/_edit_form.html.haml
@@ -13,10 +13,10 @@
   %p 削除する項目
   - event_dates.each do |event_date|
     .field
-      = form.check_box "event_dates[#{event_date.event_date}]"
+      = form.check_box "deletable_event_dates[#{event_date.id}]"
       = event_date.event_date
   .field
     = form.label '追加する候補'
-    = form.text_area :event_dates_text, size: '30x10', placeholder: '候補日程／日時を入力してください。候補の区切りは改行で判断されます。'
+    = form.text_area :event_dates_text, size: '30x10', placeholder: '候補日程／日時を入力してください。候補の区切りは改行で判断されます。また、既に存在する日程があれば登録は失敗します。'
   .actions
     = form.submit '更新'

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -10,7 +10,7 @@
       - @event.answerers&.each do |name|
         %th= name
   %tbody
-    - @event.event_dates.each do |event_date|
+    - @event.event_dates.order(:created_at).each do |event_date|
       %tr
         %th= event_date.event_date
         - if event_date.reactions.present?
@@ -22,7 +22,7 @@
           %td 0
           %td 0
           %td 0
-
+%br
 - if @event.answerers&.include?(@current_user.name)
   = link_to '出席を修正する', edit_event_reactions_path(@event.url_path)
 - else

--- a/app/views/reactions/_form.html.haml
+++ b/app/views/reactions/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: reaction_form, url: event_reactions_path(@event.url_path), local: true) do |form|
+= form_with(model: reaction_form, url: event_reactions_path(event_url_path), local: true) do |form|
   %table{ border: 1 }
     %thead
       %tr

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -206,7 +206,13 @@ RSpec.describe EventsController, type: :controller do
             expect(updated_event.title).to eq attributes[:title]
           end
 
-          it { expect{ subject }.to change{ EventDate.count }.by(0) }
+          it :aggregate_failures do
+            expect{ subject }.to change{ EventDate.count }.by(0)
+            deleted_event_date = EventDate.find_by(id: event_date.id)
+            created_event_date = EventDate.find_by(event_date: other_event_date.event_date)
+            expect(deleted_event_date).to be nil
+            expect(created_event_date).to be_truthy
+          end
         end
       end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe EventsController, type: :controller do
             deleted_event_date = EventDate.find_by(id: event_date.id)
             created_event_date = EventDate.find_by(event_date: other_event_date.event_date)
             expect(deleted_event_date).to be nil
-            expect(created_event_date).to be_truthy
+            expect(created_event_date).not_to be nil
           end
         end
       end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
   let(:user) { create(:user) }
-  let(:event) { create(:event) }
+  let(:event) { create(:event, user: user) }
   let(:valid_attributes) {
     { title: '飲み会テストタイトル',
       event_dates_text: "6/18\r06/19\n06/20\r\n6/21\r\n\r\n6/22\n\n\n6/23\r\r\r\r6/24" }
@@ -85,7 +85,7 @@ RSpec.describe EventsController, type: :controller do
     context "ログイン済みの場合" do
       before do
         event
-        log_in(event.user)
+        log_in(user)
       end
 
       context "正しいパラメーターの場合" do
@@ -128,28 +128,86 @@ RSpec.describe EventsController, type: :controller do
   end
 
   describe "PUT #update" do
+    subject { put :update, params: { url_path: event.url_path, event_form: attributes } }
+
     context "ログイン済みの場合" do
+      let(:event_date) { create(:event_date, event: event) }
+
       before do
-        event
-        log_in(event.user)
+        event_date
+        log_in(user)
       end
 
       context "正しいパラメーターの場合" do
-        before do
-          old_title
-          put :update, params: { url_path: event.url_path, event_form: attributes }
-        end
-
         let(:old_title) { event.title }
-        let(:attributes) { { title: '新飲み会テストタイトル' } }
         let(:updated_event) { Event.find_by(url_path: event.url_path) }
-
-        it :aggregate_failures do
-          expect(updated_event.title).not_to eq old_title
-          expect(updated_event.title).to eq attributes[:title]
+        let(:deletable_event_dates) do
+          deletable_event_dates = {}
+          deletable_event_dates["#{event_date.id}"] = '1'
+          deletable_event_dates
         end
 
-        it { is_expected.to redirect_to updated_event }
+        before { old_title }
+
+        context "タイトルを変更する時" do
+          let(:attributes) { { title: '新飲み会テストタイトル' } }
+
+          it :aggregate_failures do
+            subject
+            expect(updated_event.title).not_to eq old_title
+            expect(updated_event.title).to eq attributes[:title]
+          end
+
+          it { is_expected.to redirect_to event_url(updated_event.url_path) }
+        end
+
+        context "タイトルを変更し、日付を削除する場合" do
+          let(:second_event_date) { create(:event_date, event: event) }
+          let(:attributes) { { title: '新飲み会テストタイトル', deletable_event_dates: deletable_event_dates } }
+
+          before { second_event_date }
+
+          it :aggregate_failures do
+            subject
+            expect(updated_event.title).not_to eq old_title
+            expect(updated_event.title).to eq attributes[:title]
+          end
+
+          it { expect{ subject }.to change{ EventDate.count }.by(-1) }
+        end
+
+        context "タイトルを変更し、日付を追加する場合" do
+          let(:other_event_date) { build(:event_date, event: event) }
+          let(:attributes) { { title: '新飲み会テストタイトル', event_dates_text: other_event_date.event_date } }
+
+          it :aggregate_failures do
+            subject
+            expect(updated_event.title).not_to eq old_title
+            expect(updated_event.title).to eq attributes[:title]
+          end
+
+          it { expect{ subject }.to change{ EventDate.count }.by(1) }
+        end
+
+        context "日付の追加と削除を同時に行う場合" do
+          let(:other_event_date) { build(:event_date) }
+          let(:attributes) { { event_dates_text: other_event_date.event_date, deletable_event_dates: deletable_event_dates } }
+
+          it { expect{ subject }.to change{ EventDate.count }.by(0) }
+        end
+
+        context "タイトルの変更と日付の追加と削除を同時に行う場合" do
+          let(:other_event_date) { build(:event_date) }
+          let(:attributes) { { title: '新飲み会テストタイトル', event_dates_text: other_event_date.event_date, deletable_event_dates: deletable_event_dates } }
+
+          it :aggregate_failures do
+            subject
+            expect(updated_event.title).not_to eq old_title
+            expect(updated_event.title).to eq attributes[:title]
+          end
+
+          it { expect{ subject }.to change{ EventDate.count }.by(0) }
+        end
       end
 
       context "不正なパラメーターの場合" do
@@ -159,14 +217,26 @@ RSpec.describe EventsController, type: :controller do
           let(:attributes) { { title: '飲み会テストタイトル' } }
           let(:event_url_path) { 'abc' }
 
-          it { is_expected.to render_template(:edit) }
+          it { is_expected.to redirect_to events_url }
         end
 
-        context "タイトルが空の場合" do
-          let(:attributes) { { title: '' } }
+        context "日付がすでに存在している場合" do
+          let(:attributes) { { title: '飲み会テストタイトル', event_dates_text: event_date.event_date } }
           let(:event_url_path) { event.url_path }
 
-          it { is_expected.to render_template(:edit) }
+          it { is_expected.to redirect_to edit_event_url(event.url_path) }
+        end
+
+        context "存在しない日付を削除する場合" do
+          let(:attributes) { { title: '飲み会テストタイトル', deletable_event_dates: deletable_event_dates } }
+          let(:event_url_path) { event.url_path }
+          let(:deletable_event_dates) do
+            deletable_event_dates = {}
+            deletable_event_dates[100] = '1'
+            deletable_event_dates
+          end
+
+          it { is_expected.to redirect_to event_url(event.url_path) }
         end
       end
     end
@@ -186,7 +256,7 @@ RSpec.describe EventsController, type: :controller do
     context "ログイン済みの場合" do
       before do
         event
-        log_in(event.user)
+        log_in(user)
       end
 
       context "イベントが存在する場合" do
@@ -199,7 +269,7 @@ RSpec.describe EventsController, type: :controller do
       context "イベントが存在しない場合" do
         let(:params) { { url_path: 'abc' } }
 
-        it { is_expected.to render_template(:index) }
+        it { is_expected.to redirect_to events_url }
       end
     end
 

--- a/spec/controllers/reactions_controller_spec.rb
+++ b/spec/controllers/reactions_controller_spec.rb
@@ -134,4 +134,25 @@ RSpec.describe ReactionsController, type: :controller do
       it { is_expected.to redirect_to root_path }
     end
   end
+
+  describe "DELETE #destroy" do
+    subject { delete :destroy, params: { event_url_path: url_path } }
+    before do
+      log_in(user)
+      reaction
+    end
+
+    context "正しい値の場合" do
+      let(:url_path) { event.url_path }
+
+      it { expect{subject}.to change{ Reaction.count }.by(-1) }
+      it { is_expected.to redirect_to event_url(url_path) }
+    end
+
+    context "不正な値の場合" do
+      let(:url_path) { '' }
+
+      it { is_expected.to redirect_to root_path }
+    end
+  end
 end


### PR DESCRIPTION
# 目的
イベントの更新機能の作成

# 内容
イベントをユーザーが更新できるようにしました。具体的にはイベントの以下の3つの点をユーザーは更新できます。
- タイトル
- 削除する日付
- 追加する日付

またこのプルリクエストおよび #23 ではイベントを編集するユーザーをチェックするようなシステムを（コントローラーレベルでは）実装していません。それは次のPRで作成するつもりですので、その点をご了承頂けると助かります。

@matsuhisa
また、このPRに関してもレビューをよろしくお願いします。