### PR TITLE
イベント更新の認可システムの作成

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,7 @@
 class EventsController < ApplicationController
   before_action :logged_in?, except: [:index]
   before_action :set_event, :exist_or_redirect, except: [:index, :new, :create]
+  before_action :correct_user?, only: [:edit, :update, :destroy]
 
   def index
     @events = Event.all
@@ -19,7 +20,6 @@ class EventsController < ApplicationController
 
   def create
     @event_form = EventForm.new(event_params.merge({ user: current_user }))
-
     if @event_form.valid?
       @event_form.event = @event_form.create
       redirect_to event_path(@event_form.event.url_path), notice: 'Event was successfully created.'
@@ -62,6 +62,12 @@ class EventsController < ApplicationController
     def exist_or_redirect
       unless @event.present?
         redirect_to events_url
+      end
+    end
+
+    def correct_user?
+      unless current_user == @event.user
+        redirect_to events_url, notice: 'イベントを編集する権限がありません。' and return
       end
     end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,7 @@
 class EventsController < ApplicationController
   before_action :logged_in?, except: [:index]
   before_action :set_event, :exist_or_redirect, except: [:index, :new, :create]
-  before_action :correct_user?, only: [:edit, :update, :destroy]
+  before_action :event_owner?, only: [:edit, :update, :destroy]
 
   def index
     @events = Event.all
@@ -65,9 +65,7 @@ class EventsController < ApplicationController
       end
     end
 
-    def correct_user?
-      unless current_user == @event.user
-        redirect_to events_url, notice: 'イベントを編集する権限がありません。' and return
-      end
+    def event_owner?
+      redirect_to events_url, notice: 'イベントを編集する権限がありません。' and return unless @event.owner?(current_user)
     end
 end

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -36,7 +36,7 @@ class ReactionsController < ApplicationController
         redirect_to event_url(@event.url_path), notice: '出席の削除に失敗しました。'
       end
     else
-      redirect_to root_path, notice: '出席の削除に失敗しました。'
+      redirect_to root_path, notice: 'イベントが存在しません。'
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,4 +10,8 @@ class Event < ApplicationRecord
       event_dates.inject(Array.new) { |answerers, event_date| answerers |= event_date.reactions.map { |reaction| reaction.user.name } }
     end
   end
+
+  def owner?(check_user)
+    user == check_user
+  end
 end

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -10,7 +10,7 @@
       - @event.answerers&.each do |name|
         %th= name
   %tbody
-    - @event.event_dates.order(:created_at).each do |event_date|
+    - @event.event_dates.each do |event_date|
       %tr
         %th= event_date.event_date
         - if event_date.reactions.present?

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -218,15 +218,13 @@ RSpec.describe EventsController, type: :controller do
               expect(updated_event.title).to eq attributes[:title]
             end
 
-            it { expect{ subject }.to change{ EventDate.count }.by(0) }
-          end
-
-          it :aggregate_failures do
-            expect{ subject }.to change{ EventDate.count }.by(0)
-            deleted_event_date = EventDate.find_by(id: event_date.id)
-            created_event_date = EventDate.find_by(event_date: other_event_date.event_date)
-            expect(deleted_event_date).to be nil
-            expect(created_event_date).not_to be nil
+            it :aggregate_failures do
+              expect{ subject }.to change{ EventDate.count }.by(0)
+              deleted_event_date = EventDate.find_by(id: event_date.id)
+              created_event_date = EventDate.find_by(event_date: other_event_date.event_date)
+              expect(deleted_event_date).to be nil
+              expect(created_event_date).not_to be nil
+            end
           end
         end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -66,12 +66,27 @@ RSpec.describe EventsController, type: :controller do
     context "ログイン済みの場合" do
       before do
         event
-        log_in(user)
+        log_in(login_user)
       end
 
       context "イベントが存在する場合" do
-        let(:url_path) { event.url_path }
-        it { is_expected.to be_successful }
+        context "ユーザーがイベント作成者の場合" do
+          let(:login_user) { user }
+          let(:url_path) { event.url_path }
+          it { is_expected.to be_successful }
+        end
+
+        context "ユーザーがイベント作成者じゃない場合" do
+          let(:login_user) { create(:user) }
+          let(:url_path) { event.url_path }
+          it { is_expected.to redirect_to events_url  }
+        end
+      end
+
+      context "イベントが存在しない場合" do
+        let(:login_user) { user }
+        let(:url_path) { 'abc' }
+        it { is_expected.to redirect_to events_url }
       end
     end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -169,22 +169,18 @@ RSpec.describe EventsController, type: :controller do
             let(:attributes) { { title: '新飲み会テストタイトル' } }
 
             it :aggregate_failures do
-              subject
+              is_expected.to redirect_to event_url(updated_event.url_path)
               expect(updated_event.title).not_to eq old_title
               expect(updated_event.title).to eq attributes[:title]
             end
-
-            it { is_expected.to redirect_to event_url(updated_event.url_path) }
           end
 
           context "タイトルを変更し、日付を削除する場合" do
-            let(:second_event_date) { create(:event_date, event: event) }
+            let!(:second_event_date) { create(:event_date, event: event) }
             let(:attributes) { { title: '新飲み会テストタイトル', deletable_event_dates: deletable_event_dates } }
 
-            before { second_event_date }
-
             it :aggregate_failures do
-              subject
+              is_expected.to redirect_to event_url(updated_event.url_path)
               expect(updated_event.title).not_to eq old_title
               expect(updated_event.title).to eq attributes[:title]
             end
@@ -197,7 +193,7 @@ RSpec.describe EventsController, type: :controller do
             let(:attributes) { { title: '新飲み会テストタイトル', event_dates_text: other_event_date.event_date } }
 
             it :aggregate_failures do
-              subject
+              is_expected.to redirect_to event_url(updated_event.url_path)
               expect(updated_event.title).not_to eq old_title
               expect(updated_event.title).to eq attributes[:title]
             end
@@ -217,7 +213,7 @@ RSpec.describe EventsController, type: :controller do
             let(:attributes) { { title: '新飲み会テストタイトル', event_dates_text: other_event_date.event_date, deletable_event_dates: deletable_event_dates } }
 
             it :aggregate_failures do
-              subject
+              is_expected.to redirect_to event_url(updated_event.url_path)
               expect(updated_event.title).not_to eq old_title
               expect(updated_event.title).to eq attributes[:title]
             end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe EventsController, type: :controller do
         it "イベントの詳細ページへリダイレクトする" do
           subject.call
           event = Event.find_by(title: valid_attributes[:title])
-          expect(response).to redirect_to event_path(event.url_path)
+          expect(response).to redirect_to event_url(event.url_path)
         end
       end
 
@@ -138,7 +138,7 @@ RSpec.describe EventsController, type: :controller do
     context "ログインしていない場合" do
       subject { post :create, params: { event_form: valid_attributes } }
 
-      it { is_expected.to redirect_to root_path }
+      it { is_expected.to redirect_to root_url }
     end
   end
 

--- a/spec/controllers/reactions_controller_spec.rb
+++ b/spec/controllers/reactions_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe ReactionsController, type: :controller do
       context "正しい値の場合" do
         let(:url_path) { event.url_path }
 
-        it { expect{subject}.to change{ Reaction.count }.by(-1) }
+        it { expect{ subject }.to change{ Reaction.count }.by(-1) }
         it { is_expected.to redirect_to event_url(url_path) }
       end
 

--- a/spec/controllers/reactions_controller_spec.rb
+++ b/spec/controllers/reactions_controller_spec.rb
@@ -76,8 +76,7 @@ RSpec.describe ReactionsController, type: :controller do
       end
 
       context "正しい値の場合" do
-        before { old_status }
-        let(:old_status) { reaction.status }
+        let!(:old_status) { reaction.status }
         let(:attributes) { { answer: { "#{event_date.id}": '3' } } }
         let(:updated_reaction) { Reaction.find_by(id: reaction.id) }
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe SessionsController, type: :controller do
         it { expect{ subject }.to change { User.count }.by(1) }
 
         it "ログインに成功する" do
-          subject
+          is_expected.to be_truthy
           expect(is_logged_in?).to be true
         end
 
         it "ユーザー詳細ページへリダイレクトする" do
-          subject
+          is_expected.to be_truthy
           user = User.find_by(email: other_valid_attributes[:email])
           expect(response).to redirect_to user
         end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe Event, type: :model do
     end
 
     context "ユーザーがイベント作成者じゃない場合" do
-      let(:second_user) { create(:user) }
-      let(:event) { create(:event, user: second_user) }
+      let(:another_user) { create(:user) }
+      let(:event) { create(:event, user: another_user) }
       it { is_expected.to be false}
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -55,4 +55,20 @@ RSpec.describe Event, type: :model do
 
     it { is_expected.to eq [user.name, second_user.name] }
   end
+
+  describe "#owner?" do
+    subject { event.owner?(user) }
+    let(:user) { create(:user) }
+
+    context "ユーザーがイベント作成者の場合" do
+      let(:event) { create(:event, user: user) }
+      it { is_expected.to be true}
+    end
+
+    context "ユーザーがイベント作成者じゃない場合" do
+      let(:second_user) { create(:user) }
+      let(:event) { create(:event, user: second_user) }
+      it { is_expected.to be false}
+    end
+  end
 end

--- a/spec/models/reaction_form_spec.rb
+++ b/spec/models/reaction_form_spec.rb
@@ -73,10 +73,8 @@ RSpec.describe ReactionForm, type: :model do
         second_old_status
       end
 
-      it { is_expected.to be_truthy }
-
       it :aggregate_failures do
-        subject
+        is_expected.to be_truthy
         expect(updated_reaction.status).not_to eq old_status
         expect(updated_reaction.status).to eq 2
         expect(updated_second_reaction.status).not_to eq second_old_status
@@ -88,7 +86,7 @@ RSpec.describe ReactionForm, type: :model do
         before { answer["#{third_event_date.id}"] = '1' }
 
         it :aggregate_failures do
-          subject
+          is_expected.to be_truthy
           expect(updated_reaction.status).not_to eq old_status
           expect(updated_reaction.status).to eq 2
           expect(updated_second_reaction.status).not_to eq second_old_status
@@ -127,10 +125,8 @@ RSpec.describe ReactionForm, type: :model do
           second_old_status
         end
 
-        it { is_expected.to be_falsey }
-
         it :aggregate_failures do
-          subject
+          is_expected.to be_falsey
           expect(updated_reaction.status).to eq old_status
           expect(updated_reaction.status).not_to eq 2
           expect(updated_second_reaction.status).to eq second_old_status
@@ -151,10 +147,8 @@ RSpec.describe ReactionForm, type: :model do
           second_old_status
         end
 
-        it { is_expected.to be_falsey }
-
         it :aggregate_failures do
-          subject
+          is_expected.to be_falsey
           expect(updated_reaction.status).to eq old_status
           expect(updated_reaction.status).not_to eq 2
           expect(updated_second_reaction.status).to eq second_old_status

--- a/spec/models/reaction_form_spec.rb
+++ b/spec/models/reaction_form_spec.rb
@@ -3,11 +3,10 @@ require 'rails_helper'
 RSpec.describe ReactionForm, type: :model do
   describe "#create" do
     subject { form.create }
-    before { event_date }
     let(:form) { ReactionForm.new(attributes.merge({ user: user })) }
     let(:user) { create(:user) }
     let(:event) { create(:event) }
-    let(:event_date) { create(:event_date, event: event) }
+    let!(:event_date) { create(:event_date, event: event) }
     let(:second_event_date) { create(:event_date, event: event) }
     let(:attributes) { { answer: answer } }
     let(:answer) do


### PR DESCRIPTION
# 目的
イベント更新の認可システムの作成

# 内容
イベント作成者のみがイベントを編集・更新できるようにしました。

確認の方をよろしくお願いします。

追記
@matsuhisa さんもお手すきの際によろしくお願いしますm(_)m